### PR TITLE
Feature/prereg/help text

### DIFF
--- a/website/project/metadata/prereg-prize-test.json
+++ b/website/project/metadata/prereg-prize-test.json
@@ -18,7 +18,7 @@
                         "format": "text",
                         "title": "Title",
                         "description": "What is the working title of your study? It is helpful if this is the same title that you submit for publication of your final manuscript, but it is not a requirement.",
-                        "default": "Effect of sugar on brownie tastiness."
+                        "help": "Effect of sugar on brownie tastiness."
                     }
                 }
             },
@@ -33,7 +33,7 @@
                         "format": "text",
                         "title": "Authorship",
                         "description": "The first author of the pre-registered study is the recipient of the award money and must also be the first author of the published manuscript. Additional authors may be added or removed at any time.",
-                        "default": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo"
+                        "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo"
                     }
                 }
             },
@@ -48,7 +48,7 @@
                         "format": "textarea",
                         "title": "Conflict of Interest",
                         "description": "Could the results of this project benefit the financial interests of any of its authors, or be reasonably perceived to do so?",
-                        "default": "The authors of this study own a majority share of Tastee Sugar Company."
+                        "help": "The authors of this study own a majority share of Tastee Sugar Company."
                     }
                 }
             },
@@ -63,7 +63,7 @@
                         "format": "textarea",
                         "title": "Research questions and hypotheses",
                         "description": "What are your research questions and hypotheses?",
-                        "default": "There is strong evidence to suggest that sugar affects taste preferences, but the effect has never been demonstrated in brownies. Therefore, we will measure taste preference for four different levels of sugar concentration in a standard brownie recipe. If taste effects preferences, then mean preference indices will be higher with higher concentrations of sugar."
+                        "help": "There is strong evidence to suggest that sugar affects taste preferences, but the effect has never been demonstrated in brownies. Therefore, we will measure taste preference for four different levels of sugar concentration in a standard brownie recipe. If taste effects preferences, then mean preference indices will be higher with higher concentrations of sugar."
                     }
                 }
             }
@@ -84,7 +84,7 @@
                         "format": "textarea",
                         "title": "Data collection procedures",
                         "description": "Please describe your data collection procedures. This may include the population from which you obtain subjects, recruitment efforts, how subjects will be selected for eligibility from the initial pool (e.g. inclusion and exclusion rules), and your study timeline.",
-                        "default": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to  participating (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries."
+                        "help": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to  participating (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries."
                     }
                 }
             },
@@ -99,7 +99,7 @@
                         "format": "text",
                         "title": "Sample Size",
                         "description": "How many units will be analyzed in the study? This could be the number of people, birds, classrooms, plots, interactions, or countries included. If the units are not individuals, then describe the size requirements for each unit.",
-                        "default": "Our target sample size is 280 participants. We will attempt to recruit up to 320, assuming that not all will complete the total task."
+                        "help": "Our target sample size is 280 participants. We will attempt to recruit up to 320, assuming that not all will complete the total task."
                     }
                 }
             },
@@ -114,7 +114,7 @@
                         "format": "textarea",
                         "title": "Please describe your rationale for picking this sample size.",
                         "description": "This could include a power analysis or an arbitrary constraint such as resource availability. Include a stopping rule that is not dependent on investigating the data as it is collected.",
-                        "default": "We used the software program G*Power to conduct a power analysis. Our goal was to obtain .95 power to detect a medium effect size of .25 at the standard .05 alpha error probability. We will stop recruiting participants at 320 (to account for incomplete data) or after 30 days, whichever comes first."
+                        "help": "We used the software program G*Power to conduct a power analysis. Our goal was to obtain .95 power to detect a medium effect size of .25 at the standard .05 alpha error probability. We will stop recruiting participants at 320 (to account for incomplete data) or after 30 days, whichever comes first."
                     }
                 }
             },
@@ -186,7 +186,7 @@
                         "format": "text",
                         "title": "Describe your study design.",
                         "description": "Examples include two-group, factorial, randomized block, and repeated measures. Is it a between or within-subject design? Describe any counterbalancing required. Typical study designs for observation studies include cohort, cross sectional, and case-control studies. You will be asked to define your variables in detail in the upcoming sections.",
-                        "default": "In our between-subject design, each of the 280 expected participants will taste one of the four levels of brownies (1X4)"
+                        "help": "In our between-subject design, each of the 280 expected participants will taste one of the four levels of brownies (1X4)"
                     }
                 }
             },
@@ -201,7 +201,7 @@
                         "format": "textarea",
                         "title": "Define your predictor variable(s).",
                         "description": "If applicable, describe the levels for each predictor. If your predictor variables are constructed from multiple measurements, you will be asked later on to describe how they are created. ",
-                        "default": "Our predictor is the amount of sugar added per brownie. The dry ingredients for each brownie will contain 15%, 20%, 25%, or 40% cane sugar by mass."
+                        "help": "Our predictor is the amount of sugar added per brownie. The dry ingredients for each brownie will contain 15%, 20%, 25%, or 40% cane sugar by mass."
                     }
                 }
             },
@@ -216,7 +216,7 @@
                         "format": "textarea",
                         "title": "Define your outcome variable(s).",
                         "description": "If your outcome measurements are constructed from multiple measurements, you will be asked later on to describe how they are created.",
-                        "default": "The single outcome variable will be the perceived tastiness of the single brownie each participant will eat."
+                        "help": "The single outcome variable will be the perceived tastiness of the single brownie each participant will eat."
                     }
                 }
             },
@@ -231,7 +231,7 @@
                         "format": "textarea",
                         "title": "Covariates.",
                         "description": "If applicable, and not mentioned above, what covariates, controls, or other independent variables will you measure?",
-                        "default": "We will be collecting basic demographic information from each participant (age, household income, education level, housing zipcode, and marital status) and use that information for exploratory data investigation to determine if taste perception may be easily predicted. Any suggestive correlations may be the subject of future, confirmatory investigations."
+                        "help": "We will be collecting basic demographic information from each participant (age, household income, education level, housing zipcode, and marital status) and use that information for exploratory data investigation to determine if taste perception may be easily predicted. Any suggestive correlations may be the subject of future, confirmatory investigations."
                     }
                 }
             },
@@ -246,7 +246,7 @@
                         "format": "textarea",
                         "title": "If you are doing a randomized study, how will you randomize, and at what level?",
                         "description": "There are many different randomization techniques. The appropriateness of each will depend on the specifics of your study.",
-                        "default": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will e created using the web applications available at http://random.org."
+                        "help": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will e created using the web applications available at http://random.org."
                     }
                 }
             }
@@ -267,7 +267,7 @@
                         "format": "textarea",
                         "title": "Constructing predictor variables",
                         "description": "Often, a main predictor will not be a single measurement, but an index made from several other measurements. What measures will you use and how will they be combined to make your outcome variable(s).",
-                        "default": "The predictor variable (percent sugar) will not be constructed from multiple measures."
+                        "help": "The predictor variable (percent sugar) will not be constructed from multiple measures."
                     }
                 }
             },
@@ -282,7 +282,7 @@
                         "format": "textarea",
                         "title": "Constructing outcome variables",
                         "description": "Just as with the previous question, how will specific measures be combined to create your predictor variable(s)?",
-                        "default": "As taste perception is a complex variable, we will measure it by taking each users geometric mean response from three widely used indices of tastiness: the Tasty Measure Index of Sweetness (1-100 scale), the Yum Scale of Enjoyability (1-10 scale), and the Aural Pleasure Rating of Foods (1-20 scale). A geometric mean will be used because of the scale variation between each of the three indices."
+                        "help": "As taste perception is a complex variable, we will measure it by taking each users geometric mean response from three widely used indices of tastiness: the Tasty Measure Index of Sweetness (1-100 scale), the Yum Scale of Enjoyability (1-10 scale), and the Aural Pleasure Rating of Foods (1-20 scale). A geometric mean will be used because of the scale variation between each of the three indices."
                     }
                 }
             },
@@ -297,7 +297,7 @@
                         "format": "textarea",
                         "title": "How will you determine what data or samples (if any) to exclude from your analyses?",
                         "description": "Are there specific criteria that must be met in order to include? How will outliers be handled? You may want to attach a decision tree with an _if, then” structure to easily formalize the way in which these decisions will be made.",
-                        "default": "No checks will be performed to determine eligibility for inclusion besides verification that each subject answered each of the three tastiness indices. Outliers will be included in the analysis."
+                        "help": "No checks will be performed to determine eligibility for inclusion besides verification that each subject answered each of the three tastiness indices. Outliers will be included in the analysis."
                     }
                 }
             },
@@ -312,7 +312,7 @@
                         "format": "textarea",
                         "title": "How will you deal with incomplete or missing data?",
                         "description": "Almost every study will have missing data points. How you cope with these missing points is important because it can affect the result of your analysis.",
-                        "default": "If any of the three indices of tastiness are not completed by a subject, that subject will not be included in the analysis."
+                        "help": "If any of the three indices of tastiness are not completed by a subject, that subject will not be included in the analysis."
                     }
                 }
             },
@@ -327,7 +327,7 @@
                         "format": "textarea",
                         "title": "What statistical model(s) will you use to test your hypothesis(ses).",
                         "description": "Please include the type of model (e.g. ANOVA, regression, SEM, etc) as well as the specification of the model (e.g. what variables will be included). If you are using a method other than null hypothesis significance testing, such as a Bayesian method, provide the criteria you will use for making an evidence-based conclusion. Include likely alternative analyses or data transformations. ",
-                        "default": "We will use a 1x4 ANOVA to analyze our results. The categorical independent variable is _sugar” whereas the dependent variable, _taste,” is continuous. If the the ANOVA indicates that the mean taste perceptions are significantly different (p<.05), then we will use a Tukey-Kramer HSD test to determine the differences between levels. We will test the assumption of the ANOVA on equal group variance using the Bartlett test and use a Kruskal-Wallis if p<.05."
+                        "help": "We will use a 1x4 ANOVA to analyze our results. The categorical independent variable is _sugar” whereas the dependent variable, _taste,” is continuous. If the the ANOVA indicates that the mean taste perceptions are significantly different (p<.05), then we will use a Tukey-Kramer HSD test to determine the differences between levels. We will test the assumption of the ANOVA on equal group variance using the Bartlett test and use a Kruskal-Wallis if p<.05."
                     }
                 }
             },
@@ -342,7 +342,7 @@
                         "format": "textarea",
                         "title": "If you are comparing multiple conditions or testing multiple hypotheses, how will you account for this?",
                         "description": "When you conduct multiple comparisons, the odds of finding one statistically significant result because of random chance, instead of true relationships, increases. Click here for some more information.",
-                        "default": "The only possible instance of requiring adjustment or acknowledgement of multiple comparisons would be the six combinations among the four levels of the independent variable tested in the ANOVA, which will only be investigated if indicated by the ANOVA results by a Tukey HSD."
+                        "help": "The only possible instance of requiring adjustment or acknowledgement of multiple comparisons would be the six combinations among the four levels of the independent variable tested in the ANOVA, which will only be investigated if indicated by the ANOVA results by a Tukey HSD."
                     }
                 }
             }

--- a/website/static/css/registrations.css
+++ b/website/static/css/registrations.css
@@ -1,3 +1,6 @@
 .registrations-view {
     min-height: 400px;
 }
+.btn-group-vertical {
+    width: 100%;
+}

--- a/website/static/js/json-editor-extensions.js
+++ b/website/static/js/json-editor-extensions.js
@@ -228,7 +228,7 @@ JSONEditor.defaults.editors.commentableString = JSONEditor.defaults.editors.stri
 
 });
 
-/////////////// uplpad ////////////////
+/////////////// upload ////////////////
 
 JSONEditor.defaults.options.upload = function(type, file, cbs) {
     // TODO may want to change this

--- a/website/static/js/json-editor-extensions.js
+++ b/website/static/js/json-editor-extensions.js
@@ -14,7 +14,7 @@ var curentUser = window.contextVars.currentUser || {
 
 /////////////////// description placement //////////
 JSONEditor.defaults.themes.bootstrap3_OSF = JSONEditor.defaults.themes.bootstrap3.extend({
-    getFormControl: function(label, input, description, help) {
+    getFormControl: function(label, input, description) {
         var group = document.createElement("div");
 
         if (label && input.type === "checkbox") {
@@ -33,9 +33,6 @@ JSONEditor.defaults.themes.bootstrap3_OSF = JSONEditor.defaults.themes.bootstrap
             }
             if (description) {
                 group.appendChild(description);
-            }
-            if (help) {
-                group.appendChild(help);
             }
             group.appendChild(input);
         }

--- a/website/static/js/json-editor-extensions.js
+++ b/website/static/js/json-editor-extensions.js
@@ -12,9 +12,11 @@ var curentUser = window.contextVars.currentUser || {
     name: 'Anonymous'
 };
 
-// theme fix
+//////////////////// help text /////////////////////
+
+/////////////////// description placement //////////
 JSONEditor.defaults.themes.bootstrap3_OSF = JSONEditor.defaults.themes.bootstrap3.extend({
-    getFormControl: function(label, input, description) {
+    getFormControl: function(label, input, description, help) {
         var group = document.createElement("div");
 
         if(label && input.type === "checkbox") {
@@ -28,16 +30,27 @@ JSONEditor.defaults.themes.bootstrap3_OSF = JSONEditor.defaults.themes.bootstrap
         } 
         else {
             group.className += " form-group";
-            if(label) {
+            if (label) {
                 label.className += " control-label";
                 group.appendChild(label);
             }
-            if(description) group.appendChild(description);
+            if (description) {
+                group.appendChild(description);
+            }
+            if (help) {
+                group.appendChild(help);
+            }
             group.appendChild(input);
         }
 
         return group;
-  }
+  },
+  getFormInputHelp: function(text) {
+    var el = document.createElement('p');
+    el.className = 'example-block';
+    el.innerHTML = "<a>Show Example</a>";
+    return el;
+  },
 });
 
 //######### Commentable ###########
@@ -171,7 +184,16 @@ Comments.prototype.add = function() {
 JSONEditor.defaults.editors.commentableString = JSONEditor.defaults.editors.string.extend({
     build: function() {
         var self = this;
+        var help = this.schema.help;
         this._super();
+        if (this.schema.help) {
+            this.help = this.theme.getFormInputHelp(help);
+            $(this.input.previousSibling).after(this.help);
+            $( ".example-block" ).click(function() {
+                var example = '<p>' + help + '</p>';
+                $(".example-block").append(example);
+            });
+        };
 
         var $element = $('<div>', {
 			'class': 'col-md-12 m-b-md'

--- a/website/static/js/json-editor-extensions.js
+++ b/website/static/js/json-editor-extensions.js
@@ -41,13 +41,17 @@ JSONEditor.defaults.themes.bootstrap3_OSF = JSONEditor.defaults.themes.bootstrap
         }
 
         return group;
-  },
-  getFormInputHelp: function(text) {
-    var el = document.createElement('p');
-    el.className = 'example-block';
-    el.innerHTML = "<a>Show Example</a>";
-    return el;
-  },
+    },
+    getFormInputHelp: function(text) {
+        var el = document.createElement('p');
+        el.className = 'example-block';
+        el.innerHTML = '<a>Show Example</a>';
+        var el_inner = document.createElement('p');
+        el_inner.id = 'example';
+        el_inner.innerHTML = text;
+        el.appendChild(el_inner);
+        return el;
+    },
 });
 
 //######### Commentable ###########
@@ -180,14 +184,13 @@ Comments.prototype.add = function() {
 JSONEditor.defaults.editors.commentableString = JSONEditor.defaults.editors.string.extend({
     build: function() {
         var self = this;
-        var help = this.schema.help;
         this._super();
         if (this.schema.help) {
-            this.help = this.theme.getFormInputHelp(help);
+            this.help = this.theme.getFormInputHelp(this.schema.help);
             $(this.input.previousSibling).after(this.help);
+            $("#example").hide();
             $( ".example-block" ).click(function() {
-                var example = '<p>' + help + '</p>';
-                $(".example-block").append(example);
+                $("#example").slideToggle("slow");
             });
         };
 

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -109,7 +109,7 @@ RegistrationEditor.prototype.updateEditor = function(page, question) {
     self.editor = new JSONEditor(document.getElementById(self.editorId), {
         schema: question,
         startVal: self.draft().schemaData,
-        theme: 'bootstrap3',
+        theme: 'bootstrap3_OSF',
         disable_collapse: true,
         disable_edit_json: true,
         disable_properties: true,


### PR DESCRIPTION
# Purpose

Displays help text underneath description if clicked on. 
_Side note: there probably will not be examples for input that is not of type string so we should not have to extend it to other types_
# Changes
- Changed which theme the editor was using to `bootstrap3_OSF`. 
- Added `getFormInputHelp` to the `bootstrap3_OSF` theme which returns the help text element. 
- In the pre-reg schema, "default" was changed to "help" so that the editor would no longer place the help text into the input field. 
- Added help block logic to `build` of `commentableString`.
- CSS added to make all of the nav buttons the same width.
