### PR TITLE
[Feature Fix] Update File-picker

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -15,8 +15,19 @@ ko.bindingHandlers.osfUploader = {
             element.id,
             node.urls.api + 'files/grid/',
             {
-                onSelectRow: function(item) {
-                    debugger;
+                onselectrow: function(item) {
+                    console.log(item);
+                    self.preview_value = item.data;
+                    this.path = item.data.path;
+                    self.files = item.data;
+
+                    var tb = this;
+                    if (item.data.kind === 'file') {
+                        var redir = new URI(item.data.nodeUrl);
+                        redir.segment('files').segment(item.data.provider).segmentCoded(item.data.path.substring(1));
+                        var fileurl = redir.toString() + '/';
+                        console.log(fileurl);
+                    }
                 },
                 dropzone : {                                           // All dropzone options.
                     url: function(files) {return files[0].url;},
@@ -32,7 +43,7 @@ ko.bindingHandlers.osfUploader = {
         fw.init();
     },
     update: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
-        
+
     }
 };
 

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -17,6 +17,15 @@ ko.bindingHandlers.osfUploader = {
             {
                 onSelectRow: function(item) {
                     debugger;
+                },
+                dropzone : {                                           // All dropzone options.
+                    url: function(files) {return files[0].url;},
+                    clickable : "#" + element.id,
+                    addRemoveLinks: false,
+                    previewTemplate: '<div></div>',
+                    parallelUploads: 1,
+                    acceptDirectories: false,
+                    fallback: function(){}
                 }
             }
         );


### PR DESCRIPTION
# Purpose

Update file-picker to work with the new knockout approach.
# Changes

Set proper Dropzone options so that the file-picker renders. `onselectrow` option gets the path to the file and logs it to the console. Not sure what the intended functionality is so more will need to be added.
