### PR TITLE
[Feature Fix] more file picker 

### DIFF
--- a/website/static/css/registrations.css
+++ b/website/static/css/registrations.css
@@ -13,3 +13,9 @@
     font-weight: 900;
     font-size: 120%;
 }
+#selectedScript{
+    font-weight: 500;
+}
+#scriptName{
+	font-weight: 300;
+}

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -30,10 +30,11 @@ ko.bindingHandlers.osfUploader = {
                         redir.segment("files").segment(item.data.provider).segmentCoded(item.data.path.substring(1));
                         fileurl = redir.toString() + '/';
                         $("#scriptName").html(item.data.name);
-                        console.log(fileurl);
+                        viewModel.setValue(fileurl);
                     } else {
                         $("#scriptName").html("no file selected");
                         fileurl = "";
+                        viewModel.setValue(null);
                     }
                 },
                 dropzone: {                                           // All dropzone options.
@@ -57,16 +58,25 @@ ko.bindingHandlers.osfUploader = {
                             item.css = "text-muted";
                             item.data.permissions.edit = false;
                             item.data.permissions.view = false;
-                            if (!item.data.name.includes(" (Must upload from OSF Storage to ensure accurate versioning.)")) {
-                                item.data.name = item.data.name + " (Must upload from OSF Storage to ensure accurate versioning.)";
+                            if (!item.data.name.includes(" (Only OSF Storage supported to ensure accurate versioning.)")) {
+                                item.data.name = item.data.name + " (Only OSF Storage supported to ensure accurate versioning.)";
                             }
-                        } else if (item.depth === 2 && userClick === false) {
+                        } else if (item.depth === 2 && userClick === false && viewModel.value() === null) {
                             tb.multiselected([item]);
                         }
                     }
                     if (item.data.kind === "file" && item.data.provider !== "osfstorage") {
                         item.open = false;
                         item.load = false;
+                    }
+                    if (viewModel.value() !== null) {
+                        var fullPath = viewModel.value().split("/");
+                        var path = fullPath[fullPath.length - 2];
+                        var correctedPath = "/" + path;
+                        if (item.data.kind === "file" && item.data.path === correctedPath) {
+                            tb.multiselected([item]);
+                            $("#scriptName").html(item.data.name);
+                        }
                     }
                     if (tb.isMultiselected(item.id)) {
                         item.css = 'fangorn-selected';

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -36,7 +36,13 @@ ko.bindingHandlers.osfUploader = {
                     parallelUploads: 1,
                     acceptDirectories: false,
                     fallback: function(){}
-                }
+                },
+                // console.log(item);
+                // if (item.data.addonFullname !== undefined) {
+                //     if (item.data.addonFullname !== "OSF Storage") {
+                //         console.log("osf");
+                //     }
+                // }
             }
         );
         fw.init();

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -393,7 +393,6 @@ RegistrationEditor.prototype.submit = function() {
 };
 RegistrationEditor.prototype.save = function() {
     var self = this;
-    console.log(this);
 
     var metaSchema = self.draft().metaSchema;
     var schema = metaSchema.schema;

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -393,6 +393,7 @@ RegistrationEditor.prototype.submit = function() {
 };
 RegistrationEditor.prototype.save = function() {
     var self = this;
+    console.log(this);
 
     var metaSchema = self.draft().metaSchema;
     var schema = metaSchema.schema;

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -1,4 +1,7 @@
 <!-- OSF Upload -->
 <script type="text/html" id="osf-upload">
+  <div id="selectedScript">File selected for upload:  
+    <span id="scriptName">no file selected</span>
+  </div>
   <div data-bind="attr.id: $data.id, osfUploader"></div>
 </script>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -58,7 +58,7 @@
           <span class="example-block">
             <a data-bind="click: toggleExample">Show Example</a>            
             <p data-bind="visible: showExample, text: help"></p>
-          </span>         
+          </span>       
           <br />
           <br />
           <div class="row">


### PR DESCRIPTION
# Purpose

Implement suggested changes for the file picker.
# Changes
- "File selected for upload: " is displayed above the file picker. This is included in `registration-editor-extensions.mako` file. Some css was added for this in `registrations.css`. 
- When question is loaded the OSF Storage is select until the user picks something else. 
- If editing from a previous save the original file chosen is shown as selected. 
- Other data storage is greyed out and cannot be selected, files are not rendered

`RegistrationEditorExtensions.js` is where all of the logic is held for what is shown and what is not shown.
