### PR TITLE
Ko-validation for required Draft Registration Questions

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -172,6 +172,13 @@ var Question = function(data, id) {
     self.properties = data.properties || {};
     self.match = data.match || '';
 
+    if ( self.required ) {
+        self.value.extend({
+            required: true,
+            message: 'You must fill out this field'
+        });
+    }
+
     self.extra = {};
 
     self.showExample = ko.observable(false);
@@ -599,7 +606,7 @@ RegistrationEditor.prototype.check = function() {
 
     var proceed = true;
     $.each(self.flatQuestions(), function(i, question) {
-        var valid = question.valid();
+        var valid = question.value.isValid();
         proceed = proceed && valid.status;
     });
     if (!proceed) {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -176,6 +176,10 @@ var Question = function(data, id) {
         self.value.extend({
             required: true
         });
+    } else {
+      self.value.extend({
+        required: false
+      });
     }
 
     self.extra = {};
@@ -201,18 +205,6 @@ var Question = function(data, id) {
      **/
     self.isComplete = ko.computed(function() {
         return !$osf.isBlank(self.value());
-    });
-
-    /**
-     * @returns {Boolean} true if the value <input> does validate
-     **/
-    self.hasErrors = ko.computed(function() {
-        if( self.required ){
-            return self.isValid();
-        }
-        else {
-            return false;
-        }
     });
 
     /**
@@ -534,15 +526,6 @@ var RegistrationEditor = function(urls, editorId) {
         }
     });
 
-    self.markAsRequired = function() {
-
-        var questions = self.flatQuestions();
-        $.each(questions, function(idx, question) {
-            question.value.extend({ required: true});
-            question.value.required = true;
-        });
-    };
-
     self.iterObject = $osf.iterObject;
 
     // TODO: better extensions system?
@@ -819,7 +802,6 @@ RegistrationEditor.prototype.putSaveData = function(payload) {
  **/
 RegistrationEditor.prototype.save = function() {
     var self = this;
-
     var metaSchema = self.draft().metaSchema;
     var schema = metaSchema.schema;
     var data = {};

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -105,35 +105,6 @@ Comment.prototype.viewComment = function(user) {
     this.seenBy.push(user.id);
 };
 
-var validate = function(checks, message, value, required) {
-    required = required || false;
-    var valid = true;
-    var blank = $osf.isBlank(value);
-    if (required && blank) {
-        return {
-            status: false,
-            messages: ['This field is required']
-        };
-    }
-    else if (!required && blank) {
-        return {
-            status: true
-        };
-    }
-    $.each(checks, function(i, check) {
-        var passed = check(value);
-        valid = valid && passed;
-    });
-    return {
-        status: valid,
-        message: !valid ? message: ''
-    };
-};
-
-var validators = {
-    number: validate.bind(null, [$osf.not(isNaN.bind(parseFloat))], 'This field must be a numeric value')
-};
-
 /**
  * @class Question
  * Model for schema questions
@@ -207,24 +178,6 @@ var Question = function(data, id) {
         return !$osf.isBlank(self.value());
     });
 
-    /**
-     * @returns {String}
-     **/
-    self.validationMessages = ko.computed(function() {
-        var valid = self.valid();
-        return valid.message;
-    });
-    /**
-     * @returns {Boolean}
-     **/
-    self.validationStatus = ko.computed(function() {
-        var valid = self.valid();
-        return {
-            false: 'text-error',
-            true: ''
-        }[valid.status];
-    });
-
     self.init();
 };
 /**
@@ -262,23 +215,6 @@ Question.prototype.toggleExample = function(){
  **/
 Question.prototype.toggleUploader = function(){
     this.showUploader(!this.showUploader());
-};
-/**
- * @returns {object} valid
- * @returns {Boolean} valid.status
- * @returns {String[]} valid.messages
- **/
-Question.prototype.valid = function() {
-    var self = this;
-
-    var value = self.value();
-    var validator = validators[self.type];
-    if (validator) {
-        return validator(value, self.required);
-    }
-    else {
-        return validate([], '', value, self.required);
-    }
 };
 
 /**
@@ -611,14 +547,14 @@ RegistrationEditor.prototype.check = function() {
     $.each(self.flatQuestions(), function(i, question) {
         if ( question.required ) {
             var valid = question.value.isValid();
-            proceed = proceed && valid.status;
+            proceed = proceed && valid;
         }
     });
     if (!proceed) {
 
         bootbox.dialog({
-            title: "Registration not complete",
-            message: "There are errors in your registration. Please double check it and submit again",
+            title: "Registration Not Complete",
+            message: "There are errors in your registration. Please double check it and submit again.",
             buttons: {
                 success: {
                     label: "Ok",
@@ -971,10 +907,6 @@ RegistrationManager.prototype.maybeWarn = function(draft) {
 };
 
 module.exports = {
-    utilities: {
-        validators: validators,
-        validate: validate
-    },
     Comment: Comment,
     Question: Question,
     MetaSchema: MetaSchema,

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -174,8 +174,7 @@ var Question = function(data, id) {
 
     if ( self.required ) {
         self.value.extend({
-            required: true,
-            message: 'You must fill out this field'
+            required: true
         });
     }
 
@@ -202,6 +201,18 @@ var Question = function(data, id) {
      **/
     self.isComplete = ko.computed(function() {
         return !$osf.isBlank(self.value());
+    });
+
+    /**
+     * @returns {Boolean} true if the value <input> does not validate
+     **/
+    self.hasErrors = ko.computed(function() {
+        if( self.required ){
+            return self.isValid();
+        }
+        else {
+            return false;
+        }
     });
 
     /**
@@ -523,6 +534,15 @@ var RegistrationEditor = function(urls, editorId) {
         }
     });
 
+    self.markAsRequired = function() {
+
+        var questions = self.flatQuestions();
+        $.each(questions, function(idx, question) {
+            question.value.extend({ required: true});
+            question.value.required = true;
+        });
+    };
+
     self.iterObject = $osf.iterObject;
 
     // TODO: better extensions system?
@@ -606,11 +626,26 @@ RegistrationEditor.prototype.check = function() {
 
     var proceed = true;
     $.each(self.flatQuestions(), function(i, question) {
-        var valid = question.value.isValid();
-        proceed = proceed && valid.status;
+        if ( question.required ) {
+            var valid = question.value.isValid();
+            proceed = proceed && valid.status;
+        }
     });
     if (!proceed) {
-        self.showValidation(true);
+
+        bootbox.dialog({
+            title: "Registration not complete",
+            message: "There are errors in your registration. Please double check it and submit again",
+            buttons: {
+                success: {
+                    label: "Ok",
+                    className: "btn-success",
+                    callback: function() {
+                        self.showValidation(true);
+                    }
+                }
+            }
+        });
     }
     else {
         window.location = self.draft().urls.register_page;

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -204,7 +204,7 @@ var Question = function(data, id) {
     });
 
     /**
-     * @returns {Boolean} true if the value <input> does not validate
+     * @returns {Boolean} true if the value <input> does validate
      **/
     self.hasErrors = ko.computed(function() {
         if( self.required ){

--- a/website/static/js/tests/registrationUtils.test.js
+++ b/website/static/js/tests/registrationUtils.test.js
@@ -58,17 +58,6 @@ var mkMetaSchema = function() {
     return [qid, params, ms];
 };
 
-
-describe('Utilites', () => {
-    describe('validators', () => {
-        it('is valid if the value is either a number or a string that can be parsed as a number', () => {
-            assert.isTrue(utilities.validators.number('1').status);
-            assert.isTrue(utilities.validators.number(42).status);
-            assert.isFalse(utilities.validators.number('abc').status);
-        });
-    });
-});
-
 describe('Comment', () => {
     describe('#constructor', () => {
         it('loads in optional instantiation data', () => {
@@ -310,25 +299,10 @@ describe('Question', () => {
         });
     });
     describe('#isValid', () => {
-        it('is true if the Question\'s value is not empty', () => {
+        it('is true if the Question\'s value is not empty and the question is required', () => {
             assert.isFalse(q.value.isValid());
             q.value('not empty');
             assert.isTrue(q.value.isValid());
-        });
-    });
-    describe('#valid', () => {
-        it('is true if the Question\'s value passes the corresponding validator\'s checks', () => {
-            q.value('not blank');
-            assert.isTrue(q.valid().status);
-            q.type = 'number';
-            assert.isFalse(q.valid().status);
-        });
-        it('is false with a message if the field is required and blank', () => {
-            q.value(null);
-            q.required = true;
-            var valid = q.valid();
-            assert.isFalse(valid.status);
-            assert.isNotNull(valid.message);
         });
     });
     describe('#init', () => {

--- a/website/static/js/tests/registrationUtils.test.js
+++ b/website/static/js/tests/registrationUtils.test.js
@@ -275,6 +275,7 @@ describe('Question', () => {
             format: 'text',
             description: faker.lorem.sentence(),
             help: faker.lorem.sentence(),
+            required: true,
             options: [1, 1, 1].map(faker.internet.domainWord)
         };
         q = new Question(question, id);
@@ -289,6 +290,7 @@ describe('Question', () => {
             assert.equal(q.format, question.format);
             assert.equal(q.description, question.description);
             assert.equal(q.help, question.help);
+            assert.equal(q.required, question.required);
             assert.equal(q.options, question.options);
             assert.isDefined(q.value);
         });
@@ -305,6 +307,13 @@ describe('Question', () => {
             assert.isFalse(q.isComplete());
             q.value('not blank');
             assert.isTrue(q.isComplete());
+        });
+    });
+    describe('#isValid', () => {
+        it('is true if the Question\'s value is not empty', () => {
+            assert.isFalse(q.value.isValid());
+            q.value('not empty');
+            assert.isTrue(q.value.isValid());
         });
     });
     describe('#valid', () => {

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -44,7 +44,7 @@
                                            registration-editor-question-current: $root.currentQuestion().id === $data.id,
                                            list-group-item-danger: $root.showValidation() && $data.validationStatus()
                                          },
-                                         click:$root.currentQuestion.bind($root, $data)"
+                                         click: $root.currentQuestion.bind($root, $data)"
                               class="registration-editor-question list-group-item">
                             <a data-bind="attr.href: '#' + id, text: nav"></a>
                           </li>

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -40,10 +40,11 @@
                       <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
                         <span data-bind="with: page.questions[qid]">
                           <li data-bind="css: {
+                                           list-item-warning: $root.currentQuestion().hasErrors(),
                                            registration-editor-question-current: $root.currentQuestion().id === $data.id,
                                            list-group-item-danger: $root.showValidation() && $data.validationStatus()
                                          },
-                                         click: $root.currentQuestion.bind($root, $data)"
+                                         click:$root.currentQuestion.bind($root, $data)"
                               class="registration-editor-question list-group-item">
                             <a data-bind="attr.href: '#' + id, text: nav"></a>
                           </li>

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -40,7 +40,7 @@
                       <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
                         <span data-bind="with: page.questions[qid]">
                           <li data-bind="css: {
-                                           list-item-warning: $root.currentQuestion().hasErrors(),
+                                           list-item-warning: !$data.value.isValid(),
                                            registration-editor-question-current: $root.currentQuestion().id === $data.id,
                                            list-group-item-danger: $root.showValidation() && $data.validationStatus()
                                          },

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -93,17 +93,18 @@
 </div>
 
 <%def name="javascript_bottom()">
-    ${parent.javascript_bottom()}
-    <script>
-        <%
-        import json %>
-            window.contextVars = $.extend(true, {}, window.contextVars, {
-                draft: ${json.dumps(draft)}
+  ${parent.javascript_bottom()}
 
-            });
-    </script>
-    <script src=${ "/static/public/js/registration-edit-page.js" | webpack_asset}>
-    </script>
+  <% import json %>
+  <script>
+   window.contextVars = $.extend(true, {}, window.contextVars, {
+     draft: ${draft | sjson, n}
+   });
+
+  </script>
+  <script src=${ "/static/public/js/registration-edit-page.js" | webpack_asset}>
+  </script>
+
 </%def>
 
 <%include file="project/registration_editor_templates.mako" />

--- a/website/templates/project/register_draft.mako
+++ b/website/templates/project/register_draft.mako
@@ -54,7 +54,7 @@
   <% import json %>
   <script type="text/javascript">
     window.contextVars = window.contextVars || {};
-    window.contextVars.draft = ${json.dumps(draft)};
+    window.contextVars.draft = ${draft | sjson, n};
   </script>
   <script src=${"/static/public/js/register-page.js" | webpack_asset}></script>
 </%def>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -71,15 +71,7 @@
             <div class="col-md-12">
               <div class="form-group" data-bind="css: {has-success: $data.isComplete}">
                 <span data-bind="with: $root.context($data)">
-                  <span data-bind="if: $root.showValidation">
-                    <ul class="list-group" data-bind="foreach: $data.validationMessages">
-                      <li class="list-group-item">
-                        <span class="text-danger"
-                              data-bind="text: $data">
-                        </span>
-                      </li>
-                    </ul>
-                  </span>
+                  <p data-bind="validationMessage: $data.value"</p>
                   <div data-bind="template: {data: $data, name: type}"></div>
                 </span>
               </div>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -71,7 +71,16 @@
             <div class="col-md-12">
               <div class="form-group" data-bind="css: {has-success: $data.isComplete}">
                 <span data-bind="with: $root.context($data)">
-                  <p data-bind="validationMessage: $data.value"</p>
+                  <span data-bind="if: $root.showValidation">
+                    <p data-bind="validationMessage: $data.value, style: { color: '#ff0033' }"></p>
+                    <ul class="list-group" data-bind="foreach: $data.validationMessages">
+                      <li class="list-group-item">
+                        <span class="text-danger"
+                              data-bind="text: $data">
+                        </span>
+                      </li>
+                    </ul>
+                  </span>
                   <div data-bind="template: {data: $data, name: type}"></div>
                 </span>
               </div>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -72,7 +72,7 @@
               <div class="form-group" data-bind="css: {has-success: $data.isComplete}">
                 <span data-bind="with: $root.context($data)">
                   <span data-bind="if: $root.showValidation">
-                    <p data-bind="validationMessage: $data.value, style: { color: '#ff0033' }"></p>
+                    <p class="text-error" data-bind="validationMessage: $data.value"></p>
                     <ul class="list-group" data-bind="foreach: $data.validationMessages">
                       <li class="list-group-item">
                         <span class="text-danger"


### PR DESCRIPTION
## Changes:
- Cannot submit a registration until all `required` questions have
  something in their `input` field.
- When a user attempts to submit a registration with invalid questions,
  they are prompted with a bootbox saying the should check their
  registration for errors. Then, the nav pills for invalid questions
  will turn red and the message 'This field is required' will appear
  under the question. When a user fills it out, both will disappear
  without hitting the Submit button again
## Problems:
- Currently, the only way to make a Question required is to pass a
  data.required=true to the Question constructor or use the `markAsRequired`
  function included in this PR.
## UI
- When hitting register and there are still invalid questions:
  ![screen shot 2015-08-10 at 10 34 34 am](https://cloud.githubusercontent.com/assets/8905795/9173971/6ca421ac-3f4b-11e5-97c1-62f1cad0108c.png)
- After submit, errors are left:
  ![screen shot 2015-08-10 at 10 04 05 am](https://cloud.githubusercontent.com/assets/8905795/9173879/f1633b22-3f4a-11e5-8145-eb5ba935c769.png)
- All other UI is the same
