### PR TITLE
Add a post-archive hook to migrate picked files to archived files

### DIFF
--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -46,7 +46,9 @@ def archive_callback(dst):
     root_job.sent = True
     root_job.save()
     if root_job.success:
-        dst.sanction.ask(root.active_contributors())
+        # Prevent circular import with app.py
+        from website.archiver import tasks
+        tasks.archive_success.delay(dst_pk=root._id)
     else:
         archiver_utils.handle_archive_fail(
             ARCHIVER_UNCAUGHT_ERROR,

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -159,6 +159,7 @@ var Uploader = function(question) {
             question.extra({
                 selectedFileName: file.data.name,
                 viewUrl: '/project/' + file.data.nodeId + '/files/osfstorage' + file.data.path,
+                sha256: file.data.extra.hashes.sha256,
                 hasSelectedFile: true
             });
         }


### PR DESCRIPTION
The Prereg Challenge filePicker references files in the unregistered
Node, and consequently we need to add a post-archival hook to
effectively migrate these refererences to point to the registered copies
of the files. This matching is done using sha256 comparison, and is
rather ugly.
